### PR TITLE
Updated Wowza Protocols to use TLSv1.2

### DIFF
--- a/terraform/10-video-hearing-wowza/cloudconfig.tpl
+++ b/terraform/10-video-hearing-wowza/cloudconfig.tpl
@@ -160,7 +160,7 @@ write_files:
                                               <SSLProtocol>TLS</SSLProtocol>
                                               <Algorithm>SunX509</Algorithm>
                                               <CipherSuites></CipherSuites>
-                                              <Protocols></Protocols>
+                                              <Protocols>TLSv1.2</Protocols>
                                       </SSLConfig>
                                       <SocketConfiguration>
                                               <ReuseAddress>true</ReuseAddress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-9138

### Change description ###

Added a requirement for Wowza to only accept TLSv1.2 protocols

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
